### PR TITLE
Fix Spawning Rules not accounting for all Actor classes

### DIFF
--- a/ZSCRIPT.zsc
+++ b/ZSCRIPT.zsc
@@ -1,4 +1,4 @@
-version "4.5"
+version "4.10"
 
 // Event Handlers for spawning.
 #include "zscript/Event-Handlers.zs"

--- a/zscript/Event-Handlers.zs
+++ b/zscript/Event-Handlers.zs
@@ -265,15 +265,15 @@ class OffworldWaresHandler : EventHandler
 	}
 
 	// Tries to create the item via random spawning.
-	bool tryCreateItem(Inventory item, WaresSpawnItem f, int g, bool rep)
+	bool tryCreateItem(Actor thing, WaresSpawnItem f, int g, bool rep)
 	{
 		if (giveRandom(f.spawnReplaces[g].chance))
 		{
-			if (Actor.Spawn(f.spawnName, item.pos) && rep)
+			if (Actor.Spawn(f.spawnName, thing.pos) && rep)
 			{
-				if (hd_debug) console.printf(item.GetClassName().." -> "..f.spawnName);
+				if (hd_debug) console.printf(thing.GetClassName().." -> "..f.spawnName);
 
-				item.destroy();
+                thing.destroy();
 
 				return true;
 			}
@@ -298,7 +298,6 @@ class OffworldWaresHandler : EventHandler
 
 		// Pointers for specific classes.
 		let ammo = HDAmmo(e.Thing);
-		let item = Inventory(e.Thing);
 		
 		// If the thing spawned is an ammunition, add any and all items that can use this.
 		if (ammo) handleAmmoUses(ammo, candidateName);
@@ -306,7 +305,7 @@ class OffworldWaresHandler : EventHandler
 		// Return if range before replacing things.
 		if (level.MapName ~== "RANGE") return;
 
-		if (item) handleWeaponReplacements(item, ammo, candidateName);
+		handleWeaponReplacements(e.Thing, ammo, candidateName);
 	}
 
 	private void handleAmmoUses(HDAmmo ammo, string candidateName)
@@ -326,7 +325,7 @@ class OffworldWaresHandler : EventHandler
 		}
 	}
 
-	private void handleWeaponReplacements(Inventory item, HDAmmo ammo, string candidateName)
+	private void handleWeaponReplacements(Actor thing, HDAmmo ammo, string candidateName)
 	{
 		// Checks if the level has been loaded more than 1 tic.
 		bool prespawn = !(level.maptime > 1);
@@ -337,7 +336,8 @@ class OffworldWaresHandler : EventHandler
 			
 			// if an item is owned or is an ammo (doesn't retain owner ptr), 
 			// do not replace it. 
-			if ((prespawn || itemSpawnList[i].isPersistent) && (!item.owner && (!ammo || prespawn)))
+			let item = Inventory(thing);
+			if ((prespawn || itemSpawnList[i].isPersistent) && (!(item && item.owner) && (!ammo || prespawn)))
 			{
 				for (let j = 0; j < itemSpawnList[i].spawnReplaces.size(); j++)
 				{
@@ -345,7 +345,7 @@ class OffworldWaresHandler : EventHandler
 					{
 						if (hd_debug) console.printf("Attempting to replace "..candidateName.." with "..itemSpawnList[i].spawnName.."...");
 
-						if (tryCreateItem(item, itemSpawnList[i], j, itemSpawnList[i].replaceItem)) return;
+						if (tryCreateItem(thing, itemSpawnList[i], j, itemSpawnList[i].replaceItem)) return;
 					}
 				}
 			}


### PR DESCRIPTION
Seems my prior refactoring cut out any actor that wasn't an Inventory, which eliminates any possibility of replacements happening over IdleDummy spawns.  Passing around the raw Actor and only casting it into an Inventory when needed should solve that problem.