### PR TITLE
Add Raise frames to Select state

### DIFF
--- a/zscript/Weaponry/Flintlock Pistol/flintpistol.zsc
+++ b/zscript/Weaponry/Flintlock Pistol/flintpistol.zsc
@@ -259,6 +259,12 @@ class HD_FlintlockPistol:HDHandgun{
 				}
 			}
 		}
+		---- A 1 A_Raise();
+		---- A 1 A_Raise(30);
+		---- A 1 A_Raise(30);
+		---- A 1 A_Raise(24);
+		---- A 1 A_Raise(18);
+		wait;
 		goto ready;
 	deselect0:
 		FLNR A 0 A_CheckFlintlockHand();


### PR DESCRIPTION
The Flintlock Pistol didn't have any Raise frames in the Select state, so it would whip up instantly, which feels really weird.