### PR TITLE
Add Initial Build Scripts

### DIFF
--- a/.github/workflows/build-pk3/action.yml
+++ b/.github/workflows/build-pk3/action.yml
@@ -1,0 +1,9 @@
+name: Build PK3
+description: Builds the PK3
+runs:
+  using: "composite"
+  steps:
+  - uses: actions/checkout@v4
+  - uses: montudor/action-zip@v1
+    with:
+      args: zip -r "Cozis-Offworld-Wares-${{ env.SUFFIX }}.pk3" . -i graphics/* patches/* shaders/* sounds/* sprites/* voxels/* zscript/* Credits.txt CVARINFO GLDEFS KEYCONF LICENSE MAPINFO MENUDEF README.md sndinfo.txt TEXTURES ZSCRIPT.zsc

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,57 @@
+name: 'Draft New Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version you want to release.'
+        required: true
+
+jobs:
+  draft-new-release:
+    name: 'Draft a New Release'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Update Changelog
+        uses: thomaseizinger/keep-a-changelog-new-release@1.1.0
+        with:
+          version: ${{ github.event.inputs.version }}
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "Github Actions"
+          git config user.email "noreply@github.com"
+
+      - name: Commit Changelog
+        id: make-commit
+        run: |
+          git add CHANGELOG.md
+          git commit --message "Prepare release ${{ github.event.inputs.version }}"
+
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+
+      - name: Push New Branch
+        run: git push origin release/${{ github.event.inputs.version }}
+
+      - name: Create Pull Request
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: main
+          title: Release ${{ github.event.inputs.version }}
+          reviewers: ${{ github.actor }}
+          body: |
+            Hi @${{ github.actor }}!
+
+            This PR was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            I've updated the changelog file in this commit: ${{ steps.make-commit.outputs.commit }}.
+
+            Merging this PR will create a GitHub release with the new PK3.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,22 @@
+name: Nightly Build
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: build-suffix
+        shell: bash
+        run: echo "SUFFIX=${{ github.ref_name }}-$(date +'%Y%m%d')" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/workflows/build-pk3
+        env:
+          SUFFIX: ${{ steps.build-suffix.outputs.SUFFIX }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Artifacts
+          path: ./*.pk3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: "Publish New Release"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  release:
+    name: Publish New Release
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true &&
+      (startsWith(github.event.pull_request.head.ref, 'release/') || startsWith(github.event.pull_request.head.ref, 'hotfix/'))
+
+    steps:
+      - name: Extract version from branch name (for release branches)
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Extract version from branch name (for hotfix branches)
+        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#hotfix/}
+
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+
+      # Build & Publish PK3
+      - uses: actions/checkout@v4
+      - id: build-suffix
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+        shell: bash
+        run: echo "SUFFIX=${{ env.RELEASE_VERSION }}" >> "$GITHUB_OUTPUT"
+      - uses: ./.github/workflows/build-pk3
+        env:
+          SUFFIX: ${{ steps.build-suffix.outputs.SUFFIX }}
+
+      # Create Release
+      - uses: softprops/action-gh-release@v0.1.15
+        env:
+          RELEASE_VERSION: ${{ env.RELEASE_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+          files: ./*.pk3


### PR DESCRIPTION
If you're interested, I believe these should be able to get you started.

There's one important file, and that's the `.github/workflows/build-pk3/action.yml`.  This file does the actual ZIP command by pulling in the desired files into the final PK3 file.  Feel free to update/change this as necessary, as it's simply the Linux `zip` command.  The important part is the `${{ env.SUFFIX }}` piece, as that gets passed into this script from the other scripts.

Those scripts are the different ways to build the project, including a nightly build which will append the default branch as well as a date in YYYYMMDD format (e.g. `Cozis-Offworld-Wares-main-20240420.pk3`).  The other two are how I prepare and subsequently build and create the actual release.  "Draft New Release" takes the version you're planning to release and will create a branch, update the CHANGELOG.md file, and create a PR for you to review, update, and finally merge in.  Doing so will kick off the final script, which builds the PK3 with the version originally given, tag the default branch with that version and finally make a GitHub release and generate release notes.

NOTE: You will also need to enable actions as well as allow them to create/modify branches & PRs before you run these.

P.S. Currently the "Draft New Release" updates a non-existent CHANGELOG.md file, which I can add but I don't know your changelog or whether you'd be interested in even keeping one, so that will have to be worked out before this is merged.