### PR TITLE
Add Missing SNDINFO Entry

### DIFF
--- a/sndinfo.txt
+++ b/sndinfo.txt
@@ -8,6 +8,7 @@ weapons/musketrodin      muskrodi
 weapons/musketdust      muskdust
 weapons/musketcock      muskcock
 weapons/musketmake      musketmake
+weapons/musketmove      muskmove
 
 $Random weapons/musketmake { gear1 gear2 gear3 }
 gear1		gear1


### PR DESCRIPTION
Seems there's a sound being called out in the Musket's code that doesn't actually get defined.

Credit for the change goes to Hans.